### PR TITLE
Improve usability of very large pull requests.

### DIFF
--- a/src/dataStore.js
+++ b/src/dataStore.js
@@ -16,6 +16,12 @@ class DataStore { // eslint-disable-line no-unused-vars
         return DataStore[remove](key);
     }
 
+    static async hasEverBeenReviewed(filepath) {
+        const key = DataStore[getFilePathKey](filepath);
+
+        return !!(await DataStore[get](key));
+    }
+
     static async hasBeenReviewed(filepath, hash) {
         const key = DataStore[getFilePathKey](filepath);
 

--- a/src/init.js
+++ b/src/init.js
@@ -94,6 +94,55 @@ function repeatInitUIToWorkAroundCommentLoadIssue(fileDiff, count) {
     }
 }
 
+function waitForFileSectionLoad(fileSectionSelector) {
+	const fileDiffDom = document.querySelector(fileSectionSelector);
+	if (fileDiffDom) {
+		const alreadyHasButton = !!fileDiffDom.querySelector('.bbpr-buttons');
+		if (!alreadyHasButton) {
+			const fileDiff = new FileDiff(fileDiffDom);
+			fileDiff.initUI();
+			repeatInitUIToWorkAroundCommentLoadIssue(fileDiff, 0);	
+		}
+	} else {
+		setTimeout(waitForFileSectionLoad, 100, fileSectionSelector)
+	}
+}
+
+function initAnotherChanceFiles(anotherChanceFiles) {
+	anotherChanceFiles.forEach((file) => {
+		const fileSection = file.closest('.bb-udiff');
+		const fileSectionSelector = '#changeset-diff .bb-udiff[data-path="' + fileSection.dataset.identifier + '"]'
+		file.addEventListener('click', function() {
+			waitForFileSectionLoad(fileSectionSelector);
+		});
+		const fileLink = document.querySelector('#commit-files-summary li[data-file-identifier="' + fileSection.dataset.identifier + '"] a');
+		if (fileLink) {
+			fileLink.addEventListener('click', function() {
+				waitForFileSectionLoad(fileSectionSelector);
+			});
+		}
+		(async() => {
+			if (await DataStore.hasEverBeenReviewed(fileSection.dataset.identifier)) {
+				file.click();
+			}
+		})();
+	})
+}
+
+function waitForAnotherChanceFilesLoad(tries, previousAttemptFileCount) {
+	const anotherChanceFiles = document.querySelectorAll('.load-diff.try-again');
+	if (anotherChanceFiles.length === previousAttemptFileCount) {
+		tries = tries + 1;
+	} else {
+		tries = 0;
+	}
+	if (tries > 3) {
+		initAnotherChanceFiles(anotherChanceFiles);
+	} else {
+		setTimeout(waitForAnotherChanceFilesLoad, 100, tries, anotherChanceFiles.length);
+	}
+}
+
 function init() {
     initHelperMenu();
 
@@ -102,6 +151,15 @@ function init() {
         fileDiff.initUI();
         repeatInitUIToWorkAroundCommentLoadIssue(fileDiff, 0);
     });
+	
+	waitForAnotherChanceFilesLoad(0, 0);
+	
+	if (window.location.hash.indexOf('#chg-') >= 0) {
+		var identifier = window.location.hash.substring(5);
+		
+		const fileSectionSelector = '#changeset-diff .bb-udiff[data-path="' + identifier + '"]'
+		waitForFileSectionLoad(fileSectionSelector);
+	}
 }
 
 function isDiffTabActive() {

--- a/src/style.css
+++ b/src/style.css
@@ -81,10 +81,6 @@ ul.commit-files-summary li.bbpr-reviewed::after,
 .bb-udiff .bbpr-buttons button .bbpr-done {
   display: none; }
 
-.bb-udiff .diff-content-container {
-  max-height: 1000em;
-  transition: max-height 0.3s cubic-bezier(0, 0.99, 0, 1), opacity 0.3s linear; }
-
 .bb-udiff.bbpr-reviewed .bbpr-buttons button .bbpr-not-done {
   display: none; }
 
@@ -97,7 +93,4 @@ ul.commit-files-summary li.bbpr-reviewed::after,
     border-bottom: 1px solid #ccc;
     border-radius: 5px; }
   #pullrequest-diff:not(.bbpr-open-all-diffs) .bb-udiff.bbpr-reviewed .diff-content-container {
-    opacity: 0;
-    max-height: 0;
-    overflow: hidden; 
     display: none; }

--- a/src/style.css
+++ b/src/style.css
@@ -99,4 +99,5 @@ ul.commit-files-summary li.bbpr-reviewed::after,
   #pullrequest-diff:not(.bbpr-open-all-diffs) .bb-udiff.bbpr-reviewed .diff-content-container {
     opacity: 0;
     max-height: 0;
-    overflow: hidden; }
+    overflow: hidden; 
+    display: none; }

--- a/src/style.scss
+++ b/src/style.scss
@@ -120,11 +120,6 @@ ul.commit-files-summary li.bbpr-reviewed::after,
         display: none;
     }
 
-    .diff-content-container {
-        max-height: 1000em;
-        transition: max-height .3s cubic-bezier(0, .99, 0, 1), opacity .3s linear;
-    }
-
     &.bbpr-reviewed {
         .bbpr-buttons button .bbpr-not-done {
             display: none;
@@ -145,9 +140,6 @@ ul.commit-files-summary li.bbpr-reviewed::after,
             }
 
             .diff-content-container {
-                opacity: 0;
-                max-height: 0;
-                overflow: hidden;
                 display: none;
             }
         }

--- a/src/style.scss
+++ b/src/style.scss
@@ -148,6 +148,7 @@ ul.commit-files-summary li.bbpr-reviewed::after,
                 opacity: 0;
                 max-height: 0;
                 overflow: hidden;
+                display: none;
             }
         }
     }


### PR DESCRIPTION
I've addressed issues #5 and #6 by adding click listeners to the links that reload unloaded files, and once the markup is loaded the fileDiff button is added.

I've also removed the collapse animation because there's a much bigger performance boost when markup is display: none instead of max-height: 0. I didn't remove any of the previous styling though, so now that styling is sitting there unused.

Also, I didn't run any of the tests because I wasn't able to make nvm work. But I didn't modify the fileDiff or hash files anyway.